### PR TITLE
SL-1478: Add missing schema in Formtron schema

### DIFF
--- a/ui-schema.json
+++ b/ui-schema.json
@@ -14,7 +14,8 @@
         { "$ref": "#/definitions/array" },
         { "$ref": "#/definitions/object" },
         { "$ref": "#/definitions/form" },
-        { "$ref": "#/definitions/json" }
+        { "$ref": "#/definitions/json" },
+        { "$ref": "#/definitions/schema" }
       ]
     },
     "form": {
@@ -172,7 +173,7 @@
         },
         "required": {
           "type": "boolean"
-        },        
+        },
         "options": {
           "type": "array",
           "items": {
@@ -250,6 +251,20 @@
         "custom": {}
       },
       "additionalProperties": false
-    }
+    },
+    "schema": {
+      "type": "object",
+      "required": ["title", "type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["schema"]
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }    
   }
 }


### PR DESCRIPTION
This PR adds the missing schema property in Formtron's schema implemented in https://github.com/stoplightio/studio/pull/73