### PR TITLE
fix: support borderless forms with no title [SL-1726]

### DIFF
--- a/formtron-schema.json
+++ b/formtron-schema.json
@@ -25,7 +25,7 @@
     },
     "form": {
       "type": "object",
-      "required": ["title", "type", "fields"],
+      "required": ["type", "fields"],
       "properties": {
         "$schema": {
           "type": "string"

--- a/src/__stories__/Form.tsx
+++ b/src/__stories__/Form.tsx
@@ -1,0 +1,39 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+
+import { action } from '@storybook/addon-actions';
+import { withKnobs } from '@storybook/addon-knobs';
+import { boolean, text } from '@storybook/addon-knobs/react';
+
+import { Box } from '@stoplight/ui-kit';
+import { Form } from '../components/Form';
+import { StringInput } from '../components/StringInput';
+import { Theme, Tooltips } from './decorators';
+
+storiesOf('Inputs', module)
+  .addDecorator(withKnobs)
+  .addDecorator(Theme)
+  .addDecorator(Tooltips)
+  .add('Form', () => {
+    return (
+      <Box width="300px">
+        <Form
+          value={{
+            key: 'value',
+          }}
+          path={[]}
+          schema={{
+            title: text('schema.title', 'Title'),
+            required: boolean('schema.required', false),
+            fields: {
+              key: {
+                type: 'string',
+              },
+            },
+          }}
+          onChange={action('onChange')}
+          fieldComponents={{ string: StringInput }}
+        />
+      </Box>
+    );
+  });

--- a/src/__stories__/index.ts
+++ b/src/__stories__/index.ts
@@ -1,6 +1,7 @@
 // NOTE: The ordering of these imports determines the ordering in Storybook
 import './ArrayInput';
 import './CheckboxInput';
+import './Form';
 import './IntegerInput';
 import './JsonInput';
 import './MarkdownInput';

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -16,43 +16,46 @@ export const Form: React.FunctionComponent<IFormtronControl> = ({
   path,
 }) => {
   const { variant } = useDiagnostics(path);
-
-  return (
-    <Messages path={path}>
-      <FieldSet legend={schema.title} variant={variant}>
-        <i>{schema.description}</i>
-        {Object.keys(schema.fields).map((name, index) => {
-          const formId = `${name}-${index}`;
-          const propSchema = schema.fields[name];
-          if (propSchema.show) {
-            const show = evaluate(propSchema.show, value, name, true);
-            if (!show) return null;
-          }
-          if (propSchema.evalOptions) {
-            propSchema.options = evaluate(propSchema.evalOptions, value, name, []);
-          }
-          const Widget = fieldComponents[propSchema.type];
-          if (Widget === undefined) {
-            throw new Error(`No appropriate widget could be found for type "${propSchema.type}"`);
-          }
-          const el = (
-            <div key={formId}>
-              <Widget
-                id={formId}
-                value={value[name]}
-                schema={propSchema}
-                path={replaceWildcards(name, path)}
-                onChange={(val: any) => {
-                  const v = { ...value, [name]: val };
-                  onChange(v);
-                }}
-                fieldComponents={fieldComponents}
-              />
-            </div>
-          );
-          return el;
-        })}
-      </FieldSet>
-    </Messages>
+  const keys = Object.keys(schema.fields);
+  const guts = keys.map((name, index) => {
+    const formId = `${name}-${index}`;
+    const propSchema = schema.fields[name];
+    if (propSchema.show) {
+      const show = evaluate(propSchema.show, value, name, true);
+      if (!show) return null;
+    }
+    if (propSchema.evalOptions) {
+      propSchema.options = evaluate(propSchema.evalOptions, value, name, []);
+    }
+    const Widget = fieldComponents[propSchema.type];
+    if (Widget === undefined) {
+      throw new Error(`No appropriate widget could be found for type "${propSchema.type}"`);
+    }
+    const el = (
+      <div key={formId}>
+        <Widget
+          id={formId}
+          value={value[name]}
+          schema={propSchema}
+          path={replaceWildcards(name, path)}
+          onChange={(val: any) => {
+            const v = { ...value, [name]: val };
+            onChange(v);
+          }}
+          fieldComponents={fieldComponents}
+        />
+      </div>
+    );
+    return el;
+  });
+  // _optionally_ wrap in a FieldSet.
+  const contents = schema.title ? (
+    <FieldSet legend={schema.title} variant={variant}>
+      <i>{schema.description}</i>
+      {guts}
+    </FieldSet>
+  ) : (
+    guts
   );
+  return <Messages path={path}>{contents}</Messages>;
 };

--- a/ui-schema.json
+++ b/ui-schema.json
@@ -20,7 +20,7 @@
     },
     "form": {
       "type": "object",
-      "required": ["title", "type", "fields"],
+      "required": ["type", "fields"],
       "properties": {
         "$schema": {
           "type": "string"


### PR DESCRIPTION
Currently, formtron outputs a FieldSet with a legend, and uses both a required `title` and an optional `description` schema property.

For Studio, we now want more flexibility about how the title of the form is laid out so we can include a `$ref` toggle.

(Also, in later stories we will want the flexibility to seamlessly blend consecutive Formtrons into one form. Plugins will be able to register Formtron forms to handle `x-fields` and those will be added directly underneath the built-in form fields.)

This PR makes a simple backwards-compatible change. `title` is no longer required. If you leave it out, Formtron will _not_ wrap the fields in a FieldSet with a legend and a description and instead returns _just_ the fields.