### PR TITLE
feat: add 'enabled' conditional expression

### DIFF
--- a/docs/FormtronSchema.md
+++ b/docs/FormtronSchema.md
@@ -218,7 +218,7 @@ This ensures a nice top-to-bottom data dependency that keeps the form from becom
 
 ### Conditional enable/disable of fields <!-- omit in toc -->
 
-Exactly the same as for `show` except the field is called `enable`.
+Exactly the same as for `show` except the field is called `enabled`.
 
 ### Dynamic `options` for selects <!-- omit in toc -->
 

--- a/docs/FormtronSchema.md
+++ b/docs/FormtronSchema.md
@@ -4,6 +4,7 @@
 - [Mapping form fields to Object keys](#mapping-form-fields-to-object-keys)
 - [Escaping literal '\*' and '?' in paths](#escaping-literal--and--in-paths)
 - [Conditional / Dynamic behavior](#conditional--dynamic-behavior)
+  - [Conditional enable/disable of fields ](#conditional-enabledisable-of-fields)
 - [Primitive Field Types](#primitive-field-types)
 - [Complex Field Types](#complex-field-types)
 - [Layouts](#layouts)
@@ -211,9 +212,14 @@ Just add a `show` property to a form field with a JavaScript expression in a str
 ```
 
 The variables used in expressions are the field keys, trimmed after the last period.
+(Setting an `area` overrides this and will use that as the variable name.)
 You can only reference a field that precedes the current field.
 (E.g. you cannot have a field's visibility depend on its own value, or the value of a field below it.)
 This ensures a nice top-to-bottom data dependency that keeps the form from becoming a nightmare to debug.
+
+### Conditional enable/disable of fields <!-- omit in tsc -->
+
+Exactly the same as for `show` except the field is called `enable`.
 
 ### Dynamic `options` for selects <!-- omit in toc -->
 

--- a/docs/FormtronSchema.md
+++ b/docs/FormtronSchema.md
@@ -4,7 +4,6 @@
 - [Mapping form fields to Object keys](#mapping-form-fields-to-object-keys)
 - [Escaping literal '\*' and '?' in paths](#escaping-literal--and--in-paths)
 - [Conditional / Dynamic behavior](#conditional--dynamic-behavior)
-  - [Conditional enable/disable of fields ](#conditional-enabledisable-of-fields)
 - [Primitive Field Types](#primitive-field-types)
 - [Complex Field Types](#complex-field-types)
 - [Layouts](#layouts)
@@ -217,7 +216,7 @@ You can only reference a field that precedes the current field.
 (E.g. you cannot have a field's visibility depend on its own value, or the value of a field below it.)
 This ensures a nice top-to-bottom data dependency that keeps the form from becoming a nightmare to debug.
 
-### Conditional enable/disable of fields <!-- omit in tsc -->
+### Conditional enable/disable of fields <!-- omit in toc -->
 
 Exactly the same as for `show` except the field is called `enable`.
 

--- a/formtron-schema.json
+++ b/formtron-schema.json
@@ -16,10 +16,10 @@
         "show": {
           "type": "string"
         },
-        "area": {
+        "enabled": {
           "type": "string"
         },
-        "enabled": {
+        "area": {
           "type": "string"
         },
         "custom": {}

--- a/formtron-schema.json
+++ b/formtron-schema.json
@@ -19,8 +19,8 @@
         "area": {
           "type": "string"
         },
-        "disabled": {
-          "type": "boolean"
+        "enabled": {
+          "type": "string"
         },
         "custom": {}
       },

--- a/formtron-schema.json
+++ b/formtron-schema.json
@@ -19,6 +19,9 @@
         "area": {
           "type": "string"
         },
+        "disabled": {
+          "type": "boolean"
+        },
         "custom": {}
       },
       "additionalProperties": true

--- a/src/__stories__/examples/enable/data.json
+++ b/src/__stories__/examples/enable/data.json
@@ -1,0 +1,19 @@
+{
+  "_selection": "securityDefinitions.petstore_auth",
+  "securityDefinitions": {
+      "petstore_auth": {
+          "type": "oauth2",
+          "authorizationUrl": "https://petstore.swagger.io/oauth/dialog",
+          "flow": "implicit",
+          "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+          }
+      },
+      "api_key": {
+          "type": "apiKey",
+          "name": "api_key",
+          "in": "header"
+      }
+  }
+}

--- a/src/__stories__/examples/enable/schema.json
+++ b/src/__stories__/examples/enable/schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "../../../../ui-schema.json",
+  "type": "form",
+  "title": "Security",
+  "description": "A shared security scheme definition",
+  "fields": {
+    "securityDefinitions.?": {
+      "type": "string",
+      "title": "securityId"
+    },
+    "securityDefinitions.*.type": {
+      "type": "select",
+      "title": "Type",
+      "options": ["basic", "apiKey", "oauth2"]
+    },
+    "securityDefinitions.*.description": {
+      "type": "string",
+      "title": "Description"
+    },
+    "securityDefinitions.*.name": {
+      "type": "string",
+      "title": "Name",
+      "enabled": "type === 'apiKey'"
+    },
+    "securityDefinitions.*.in": {
+      "type": "select",
+      "title": "In",
+      "options": ["query", "header"],
+      "enabled": "type === 'apiKey'"
+    },
+    "securityDefinitions.*.flow": {
+      "type": "select",
+      "title": "Flow",
+      "options": ["implicit", "password", "application", "accessCode"],
+      "enabled": "type === 'oauth2'"
+    },
+    "securityDefinitions.*.authorizationUrl": {
+      "type": "string",
+      "title": "Authorization URL",
+      "enabled": "type === 'oauth2' && (flow === 'implicit' || flow === 'accessCode')"
+    },
+    "securityDefinitions.*.tokenUrl": {
+      "type": "string",
+      "title": "Token URL",
+      "enabled": "type === 'oauth2' && (flow === 'password' || flow === 'application' || flow === 'accessCode')"
+    },
+    "securityDefinitions.*.scopes": {
+      "type": "object",
+      "title": "Scopes",
+      "default": "",
+      "keys": {
+        "type": "string",
+        "title": "Name"
+      },
+      "values": {
+        "type": "string",
+        "title": "Description"
+      },
+      "enabled": "type === 'oauth2'"
+    }
+  }
+}

--- a/src/__stories__/stories.tsx
+++ b/src/__stories__/stories.tsx
@@ -38,6 +38,9 @@ const objectSchema = require('./examples/object/schema.json');
 const showData = require('./examples/show/data.json');
 const showSchema = require('./examples/show/schema.json');
 
+const enableData = require('./examples/enable/data.json');
+const enableSchema = require('./examples/enable/schema.json');
+
 const evalOptionsData = require('./examples/evalOptions/data.json');
 const evalOptionsSchema = require('./examples/evalOptions/schema.json');
 
@@ -81,6 +84,9 @@ storiesOf('formtron', module)
   })
   .add('show', () => {
     return <FormtronDebugger input={showData} schema={showSchema} selection={showData._selection} />;
+  })
+  .add('enable', () => {
+    return <FormtronDebugger input={enableData} schema={enableSchema} selection={enableData._selection} />;
   })
   .add('evalOptions', () => {
     return (

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -92,7 +92,7 @@ export const Form: React.FunctionComponent<IFormtronControl> = ({
                 onChange(v);
               }}
               fieldComponents={fieldComponents}
-              disabled={disabled}
+              disabled={disabled || propSchema.disabled}
               layout={layout}
             />
           </Box>

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -26,6 +26,7 @@ export const Form: React.FunctionComponent<IFormtronControl> = ({
   const { title, description, fields, layouts } = schema;
 
   const gridAreaToName = {};
+  const shortValue = {};
   const fallbackRows = [];
   let contentElems: React.ReactElement | React.ReactElement[] = [];
 
@@ -33,6 +34,7 @@ export const Form: React.FunctionComponent<IFormtronControl> = ({
     const { area } = fields[fieldName];
     const gridArea = area || shortName(fieldName);
     gridAreaToName[gridArea] = fieldName;
+    shortValue[gridArea] = value[fieldName];
     fallbackRows.push([gridArea]);
   }
 
@@ -59,15 +61,21 @@ export const Form: React.FunctionComponent<IFormtronControl> = ({
       const formId = `${name}-${index}`;
 
       const propSchema = schema.fields[name];
-      const { show, evalOptions, type } = propSchema;
+      const { show, evalOptions, enabled, type } = propSchema;
 
       // if evalutating show is false skip area
-      if (show && !evaluate(show, value, name, true)) {
+      if (show && !evaluate(show, shortValue, gridArea, true)) {
         return;
       }
 
       if (evalOptions) {
-        propSchema.options = evaluate(evalOptions, value, name, []);
+        propSchema.options = evaluate(evalOptions, shortValue, gridArea, []);
+      }
+
+      // 'disabled' here is a form-level prop bool
+      // 'enabled' is a propSchema level string
+      if (!disabled && enabled) {
+        disabled = !evaluate(enabled, shortValue, gridArea, true);
       }
 
       const Widget = fieldComponents[type];
@@ -92,7 +100,7 @@ export const Form: React.FunctionComponent<IFormtronControl> = ({
                 onChange(v);
               }}
               fieldComponents={fieldComponents}
-              disabled={disabled || propSchema.disabled}
+              disabled={disabled}
               layout={layout}
             />
           </Box>

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -72,7 +72,7 @@ export const Form: React.FunctionComponent<IFormtronControl> = ({
         propSchema.options = evaluate(evalOptions, shortValue, gridArea, []);
       }
 
-      const enableField = enabled ? evaluate(enabled, shortValue, gridArea, true) : true;
+      const enableField = !enabled || evaluate(enabled, shortValue, gridArea, true);
 
       const Widget = fieldComponents[type];
       if (Widget === undefined) {

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -72,11 +72,7 @@ export const Form: React.FunctionComponent<IFormtronControl> = ({
         propSchema.options = evaluate(evalOptions, shortValue, gridArea, []);
       }
 
-      // 'disabled' here is a form-level prop bool
-      // 'enabled' is a propSchema level string
-      if (!disabled && enabled) {
-        disabled = !evaluate(enabled, shortValue, gridArea, true);
-      }
+      const enableField = enabled ? evaluate(enabled, shortValue, gridArea, true) : true;
 
       const Widget = fieldComponents[type];
       if (Widget === undefined) {
@@ -100,7 +96,7 @@ export const Form: React.FunctionComponent<IFormtronControl> = ({
                 onChange(v);
               }}
               fieldComponents={fieldComponents}
-              disabled={disabled}
+              disabled={disabled || !enableField}
               layout={layout}
             />
           </Box>

--- a/src/components/evaluate.ts
+++ b/src/components/evaluate.ts
@@ -1,6 +1,5 @@
 const expr = require('expression-eval');
 const memoize = require('lodash/memoize');
-import { shortName } from './utils/shortName';
 
 // Compile expression or return cached compiled expression
 const compile = memoize(expr.compile);
@@ -12,8 +11,7 @@ export function evaluate(str: string, context: any, currentProp: string, fallbac
     // Only consider properties ABOVE the current property in the schema
     // (This enforces a top-to-bottom data dependency which is just nice.)
     if (prop === currentProp) break;
-    const short = shortName(prop);
-    _context[short] = context[prop];
+    _context[prop] = context[prop];
   }
   // Evaluate expression
   try {

--- a/ui-schema.json
+++ b/ui-schema.json
@@ -45,6 +45,9 @@
         "show": {
           "type": "string"
         },
+        "disabled": {
+          "type": "boolean"
+        },
         "layouts": {
           "type": "object",
           "additionalProperties": {
@@ -78,6 +81,9 @@
         "show": {
           "type": "string"
         },
+        "disabled": {
+          "type": "boolean"
+        },
         "area": {
           "type": "string"
         },
@@ -104,6 +110,9 @@
         },
         "show": {
           "type": "string"
+        },
+        "disabled": {
+          "type": "boolean"
         },
         "area": {
           "type": "string"
@@ -135,6 +144,9 @@
         "show": {
           "type": "string"
         },
+        "disabled": {
+          "type": "boolean"
+        },
         "area": {
           "type": "string"
         },
@@ -158,6 +170,9 @@
         },
         "show": {
           "type": "string"
+        },
+        "disabled": {
+          "type": "boolean"
         },
         "area": {
           "type": "string"
@@ -191,6 +206,9 @@
         },
         "show": {
           "type": "string"
+        },
+        "disabled": {
+          "type": "boolean"
         },
         "area": {
           "type": "string"
@@ -231,6 +249,9 @@
         "show": {
           "type": "string"
         },
+        "disabled": {
+          "type": "boolean"
+        },
         "area": {
           "type": "string"
         },
@@ -270,6 +291,9 @@
         "show": {
           "type": "string"
         },
+        "disabled": {
+          "type": "boolean"
+        },
         "area": {
           "type": "string"
         },
@@ -295,6 +319,9 @@
         "items": { "$ref": "#/definitions/field" },
         "show": {
           "type": "string"
+        },
+        "disabled": {
+          "type": "boolean"
         },
         "area": {
           "type": "string"
@@ -323,6 +350,9 @@
         "show": {
           "type": "string"
         },
+        "disabled": {
+          "type": "boolean"
+        },
         "area": {
           "type": "string"
         },
@@ -343,6 +373,9 @@
         },
         "show": {
           "type": "string"
+        },
+        "disabled": {
+          "type": "boolean"
         },
         "area": {
           "type": "string"

--- a/ui-schema.json
+++ b/ui-schema.json
@@ -45,8 +45,8 @@
         "show": {
           "type": "string"
         },
-        "disabled": {
-          "type": "boolean"
+        "enabled": {
+          "type": "string"
         },
         "layouts": {
           "type": "object",
@@ -81,8 +81,8 @@
         "show": {
           "type": "string"
         },
-        "disabled": {
-          "type": "boolean"
+        "enabled": {
+          "type": "string"
         },
         "area": {
           "type": "string"
@@ -111,8 +111,8 @@
         "show": {
           "type": "string"
         },
-        "disabled": {
-          "type": "boolean"
+        "enabled": {
+          "type": "string"
         },
         "area": {
           "type": "string"
@@ -144,8 +144,8 @@
         "show": {
           "type": "string"
         },
-        "disabled": {
-          "type": "boolean"
+        "enabled": {
+          "type": "string"
         },
         "area": {
           "type": "string"
@@ -171,8 +171,8 @@
         "show": {
           "type": "string"
         },
-        "disabled": {
-          "type": "boolean"
+        "enabled": {
+          "type": "string"
         },
         "area": {
           "type": "string"
@@ -207,8 +207,8 @@
         "show": {
           "type": "string"
         },
-        "disabled": {
-          "type": "boolean"
+        "enabled": {
+          "type": "string"
         },
         "area": {
           "type": "string"
@@ -249,8 +249,8 @@
         "show": {
           "type": "string"
         },
-        "disabled": {
-          "type": "boolean"
+        "enabled": {
+          "type": "string"
         },
         "area": {
           "type": "string"
@@ -291,8 +291,8 @@
         "show": {
           "type": "string"
         },
-        "disabled": {
-          "type": "boolean"
+        "enabled": {
+          "type": "string"
         },
         "area": {
           "type": "string"
@@ -320,8 +320,8 @@
         "show": {
           "type": "string"
         },
-        "disabled": {
-          "type": "boolean"
+        "enabled": {
+          "type": "string"
         },
         "area": {
           "type": "string"
@@ -350,8 +350,8 @@
         "show": {
           "type": "string"
         },
-        "disabled": {
-          "type": "boolean"
+        "enabled": {
+          "type": "string"
         },
         "area": {
           "type": "string"
@@ -374,8 +374,8 @@
         "show": {
           "type": "string"
         },
-        "disabled": {
-          "type": "boolean"
+        "enabled": {
+          "type": "string"
         },
         "area": {
           "type": "string"


### PR DESCRIPTION
**feature: Make fields enabled / disabled using a conditional expression**

Note: I don't actually need the dynamic bit for my $ref toggle, but it seemed like it should be dynamic.

So in my ref toggle schemas, I'm just using
```json
  "enabled": "false"
```

but you could do something fancier like:
```json
  "enabled": "$ref !== undefined"
```
